### PR TITLE
update to get pre-term info

### DIFF
--- a/AceBanner.Db/dbo/Stored Procedures/usp_DownloadCourseRoster.sql
+++ b/AceBanner.Db/dbo/Stored Procedures/usp_DownloadCourseRoster.sql
@@ -19,7 +19,7 @@ BEGIN
 		from sfrstcr
 			inner join wormoth on sfrstcr_pidm = wormoth_pidm
 		where sfrstcr_term_code in ( select stvterm_code from stvterm
-									where (stvterm_start_date < sysdate and stvterm_end_date > sysdate)
+									where (stvterm_start_date < sysdate + 21 and stvterm_end_date > sysdate)
 									   or (stvterm_start_date < sysdate and stvterm_end_date > sysdate - 21)
 									)
 			and sfrstcr_rsts_code in (''RE'', ''RW'')

--- a/AceBanner.Db/dbo/Stored Procedures/usp_DownloadCourses.sql
+++ b/AceBanner.Db/dbo/Stored Procedures/usp_DownloadCourses.sql
@@ -46,8 +46,8 @@ BEGIN
 					) maxscb on SCBCRSE_SUBJ_CODE = maxscb.subj and SCBCRSE_CRSE_NUMB = maxscb.crse and SCBCRSE_EFF_TERM = maxscb.term
 			) course on ssbsect_subj_code = scbcrse_subj_code and ssbsect_crse_numb = scbcrse_crse_numb
 		where ssbsect_term_code in ( select stvterm_code from stvterm
-									where (stvterm_start_date < (sysdate + 21) and stvterm_end_date > sysdate)
-									   or (stvterm_start_date < (sysdate - 1) and stvterm_end_date > (sysdate - 21))
+									where (stvterm_start_date < sysdate + 21 and stvterm_end_date > sysdate)
+									   or (stvterm_start_date < sysdate and stvterm_end_date > (sysdate - 21))
 								  )
 		  and course.scbcrse_dept_code is not null
 	')

--- a/AceBanner.Db/dbo/Stored Procedures/usp_DownloadCourses.sql
+++ b/AceBanner.Db/dbo/Stored Procedures/usp_DownloadCourses.sql
@@ -46,7 +46,7 @@ BEGIN
 					) maxscb on SCBCRSE_SUBJ_CODE = maxscb.subj and SCBCRSE_CRSE_NUMB = maxscb.crse and SCBCRSE_EFF_TERM = maxscb.term
 			) course on ssbsect_subj_code = scbcrse_subj_code and ssbsect_crse_numb = scbcrse_crse_numb
 		where ssbsect_term_code in ( select stvterm_code from stvterm
-									where (stvterm_start_date < (sysdate - 1) and stvterm_end_date > sysdate)
+									where (stvterm_start_date < (sysdate + 21) and stvterm_end_date > sysdate)
 									   or (stvterm_start_date < (sysdate - 1) and stvterm_end_date > (sysdate - 21))
 								  )
 		  and course.scbcrse_dept_code is not null

--- a/AceBanner.Db/dbo/Stored Procedures/usp_DownloadCourses.sql
+++ b/AceBanner.Db/dbo/Stored Procedures/usp_DownloadCourses.sql
@@ -47,7 +47,7 @@ BEGIN
 			) course on ssbsect_subj_code = scbcrse_subj_code and ssbsect_crse_numb = scbcrse_crse_numb
 		where ssbsect_term_code in ( select stvterm_code from stvterm
 									where (stvterm_start_date < sysdate + 21 and stvterm_end_date > sysdate)
-									   or (stvterm_start_date < sysdate and stvterm_end_date > (sysdate - 21))
+									   or (stvterm_start_date < sysdate and stvterm_end_date > sysdate - 21)
 								  )
 		  and course.scbcrse_dept_code is not null
 	')

--- a/AceBanner.Db/dbo/Stored Procedures/usp_DownloadInstructors.sql
+++ b/AceBanner.Db/dbo/Stored Procedures/usp_DownloadInstructors.sql
@@ -32,7 +32,7 @@ select * from openquery (sis, '
 		) Emails on Emails.pidm = spriden_pidm
 	where zsvinst_term_code in (
 		select stvterm_code from stvterm
-		where (stvterm_start_date < sysdate and stvterm_end_date > sysdate)
+		where (stvterm_start_date < sysdate + 21 and stvterm_end_date > sysdate)
 		   or (stvterm_start_date < sysdate and stvterm_end_date > sysdate - 21)
 	  )
 	  and zsvinst_id is not null

--- a/AceBanner.Db/dbo/Stored Procedures/usp_DownloadSections.sql
+++ b/AceBanner.Db/dbo/Stored Procedures/usp_DownloadSections.sql
@@ -27,7 +27,7 @@ BEGIN
 		from ssrmeet
 			inner join stvschd on ssrmeet_schd_code = stvschd_code
 		where ssrmeet_term_code in ( select stvterm_code from stvterm
-										where (stvterm_start_date < sysdate and stvterm_end_date > sysdate)
+										where (stvterm_start_date < sysdate + 21 and stvterm_end_date > sysdate)
 										   or (stvterm_start_date < sysdate and stvterm_end_date > sysdate - 21)
 									  )
 	')

--- a/AceBanner.Db/dbo/Stored Procedures/usp_DownloadStudents.sql
+++ b/AceBanner.Db/dbo/Stored Procedures/usp_DownloadStudents.sql
@@ -32,7 +32,7 @@ BEGIN
 				select sfrstcr_pidm
 				from sfrstcr
 				where sfrstcr_term_code in ( select stvterm_code from stvterm
-											where (stvterm_start_date < sysdate and stvterm_end_date > sysdate)
+											where (stvterm_start_date < sysdate + 21 and stvterm_end_date > sysdate)
 											   or (stvterm_start_date < sysdate and stvterm_end_date > sysdate - 21)
 										  )
 				  and sfrstcr_rsts_code in (''RE'', ''RW'')


### PR DESCRIPTION
The idea here is we want to get information for terms up to 3 weeks before they start until 3 weeks after they end.

Prior, we used to get info only when the term was open and up to 3 weeks after.

I think this change should be simple, but please take a look.